### PR TITLE
Randomize RNG seeds

### DIFF
--- a/engine/batch_runner.py
+++ b/engine/batch_runner.py
@@ -31,7 +31,7 @@ class BatchRunner:
                  n_paths: int,
                  tickers: List[str],
                  monthly_contrib: float = 100.0,
-                 seed: int = 0):
+                 seed: int | None = None):
 
         self.n_paths = n_paths
         self.tickers = tickers
@@ -46,7 +46,7 @@ class BatchRunner:
         }
         self.weights = np.array([TARGET_ALLOC[t] for t in tickers])
 
-        # Create a single master RNG
+        # Create a single master RNG (seed=None → random)
         self.master_rng = np.random.default_rng(seed)
 
         # Initialize modules without giving them their own seeds…

--- a/engine/event_tree_engine.py
+++ b/engine/event_tree_engine.py
@@ -24,11 +24,12 @@ class EventTreeEngine:
                  events_path: str | Path,
                  tickers: List[str],
                  horizon_years: int = 40,
-                 seed: int = 0):
+                 seed: int | None = None):
         # Load all events from JSON
         self.events = self._load_events(events_path)
         self.tickers = tickers
         self.horizon = horizon_years
+        # seed=None → nondeterministic RNG
         self.rng = np.random.default_rng(seed)
 
         # Map id → Event for quick lookup
@@ -142,16 +143,14 @@ if __name__ == "__main__":
                "ISPY","NUCG","SGLN"]
 
     ts = TimelineSampler(
-        Path(__file__).parents[1] / "data" / "timeline_buckets.json",
-        seed=42
+        Path(__file__).parents[1] / "data" / "timeline_buckets.json"
     )
     tl = ts.sample_timeline()
     print("Sampled timeline:", tl)
 
     et = EventTreeEngine(
         Path(__file__).parents[1] / "data" / "events_catalogue.json",
-        tickers=tickers,
-        seed=42
+        tickers=tickers
     )
     out = et.simulate(tl)
     print("Fired events:", [e.id for e in out["fired"]])

--- a/engine/timeline_sampler.py
+++ b/engine/timeline_sampler.py
@@ -31,7 +31,7 @@ class Bucket:
 # ---------- Sampler class -----------------------------------------------------
 
 class TimelineSampler:
-    def __init__(self, cfg_path: str | Path, seed: int = 0):
+    def __init__(self, cfg_path: str | Path, seed: int | None = None):
         cfg_path = Path(cfg_path)
         with open(cfg_path, "r") as f:
             cfg = json.load(f)
@@ -44,6 +44,7 @@ class TimelineSampler:
             raise ValueError("Bucket probabilities must sum to 1.")
 
         self._bucket_probs = np.array(probs, dtype=float)
+        # seed=None → nondeterministic RNG
         self.rng = np.random.default_rng(seed)
 
     # -------------------------------------------------------------------------
@@ -87,8 +88,7 @@ class TimelineSampler:
 # Stand-alone test
 # -----------------------------------------------------------------------------#
 if __name__ == "__main__":
-    ts = TimelineSampler(Path(__file__).parents[1] / "data" / "timeline_buckets.json",
-                         seed=42)
+    ts = TimelineSampler(Path(__file__).parents[1] / "data" / "timeline_buckets.json")
     for _ in range(3):
         tl = ts.sample_timeline()
         print("Sampled:", tl)

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@
 """
 Entry-point for the AI scenario Monte-Carlo engine.
 Usage:
-    python main.py --paths 20000 --contrib 100 --seed 0
+    python main.py --paths 20000 --contrib 100 [--seed SEED]
 """
 
 import argparse
@@ -25,8 +25,8 @@ def main() -> None:
                     help="number of Monte-Carlo worlds")
     ap.add_argument("--contrib", type=float, default=100.0,
                     help="monthly contribution (£)")
-    ap.add_argument("--seed",    type=int,   default=0,
-                    help="PRNG seed for reproducibility")
+    ap.add_argument("--seed",    type=int,   default=None,
+                    help="optional PRNG seed for reproducibility")
     args = ap.parse_args()
 
     # ----------------------------------------------------------------- tickers ---
@@ -64,7 +64,8 @@ def main() -> None:
     print("\nMonte-Carlo complete ✅")
     print(f"Worlds simulated  : {args.paths:,}")
     print(f"Monthly contrib £ : {args.contrib}")
-    print("Seed              :", args.seed)
+    seed_label = args.seed if args.seed is not None else "random"
+    print("Seed              :", seed_label)
     print("Summary JSON      :", json_path)
     print("Master CSV        :", csv_path)
     print("Fan chart PNG     :", f"results/fan_chart_{stamp}.png")


### PR DESCRIPTION
## Summary
- randomize RNG seed defaults across engine modules
- update usage and console printouts to reflect optional seed argument
- remove static seed values from example scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `python main.py --paths 10 --contrib 5` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6840d399e89c832c91a4b9084dbb3d32